### PR TITLE
Python 3 porting changes:

### DIFF
--- a/KalturaClient.py
+++ b/KalturaClient.py
@@ -11,9 +11,9 @@ import os
 
 from poster.streaminghttp import register_openers
 from poster.encode import multipart_encode
-import urllib2
+import urllib.request
 
-# Register the streaming http handlers with urllib2
+# Register the streaming http handlers with urllib.request
 register_openers()
 
 pluginsFolder = os.path.normpath(os.path.join(os.path.dirname(__file__), 'KalturaPlugins'))
@@ -163,16 +163,17 @@ class KalturaClient:
                 paramsdict = params.get()
                 paramsdict = {key.encode('utf-8'): paramsdict[key].encode('utf-8') for key in paramsdict}
                 f = urllib.urlopen(url, urllib.urlencode(paramsdict))
-            except Exception, e:
+            #except Exception, e:
+            except Exception as e:
                 raise KalturaClientException(e, KalturaClientException.ERROR_CONNECTION_FAILED)
         else:
             fullParams = params
             fullParams.update(files)
             datagen, headers = multipart_encode(fullParams.get())
-            request = urllib2.Request(url, datagen, headers)
+            request = urllib.request.Request(url, datagen, headers)
             try:
-                f = urllib2.urlopen(request)
-            except Exception, e:
+                f = urllib.request.urlopen(request)
+            except Exception as e:
                 raise KalturaClientException(e, KalturaClientException.ERROR_CONNECTION_FAILED)
         return f
 
@@ -184,9 +185,9 @@ class KalturaClient:
         try:
             try:
                 data = f.read()
-            except AttributeError, e:      # socket was closed while reading
+            except Exception as e:
                 raise KalturaClientException(e, KalturaClientException.ERROR_READ_TIMEOUT)
-            except Exception, e:
+            except Exception as e:
                 raise KalturaClientException(e, KalturaClientException.ERROR_READ_FAILED)
         finally:
             if requestTimeout != None:
@@ -219,7 +220,7 @@ class KalturaClient:
 
         try:        
             resultXml = minidom.parseString(postResult)
-        except ExpatError, e:
+        except Exception as e:
             raise KalturaClientException(e, KalturaClientException.ERROR_INVALID_XML)
             
         resultNode = getChildNodeByXPath(resultXml, 'xml/result')

--- a/filetypes_fallback.py
+++ b/filetypes_fallback.py
@@ -96,10 +96,10 @@ def get_KalturaMediaType_from_pull_url(purl, default):
             uo.read(10240), mime=True).split('/')[0].upper()
         uo.close()
     except:
-        print 'couldn\'t find type via magic, using ext...'
+        print ('couldn\'t find type via magic, using ext...')
         magic_type = check_type(os.path.splitext(purl)[1].lstrip('.'))
     if magic_type == 'APPLICATION':
-        print 'magic returned arbitrary type (application/x-octet-stream thingy), tryna use ext instead'
+        print ('magic returned arbitrary type (application/x-octet-stream thingy), tryna use ext instead')
         magic_type = check_type(os.path.splitext(purl)[1].lstrip('.'))
     if magic_type == 'VIDEO':
         return KalturaMediaType.VIDEO
@@ -108,13 +108,13 @@ def get_KalturaMediaType_from_pull_url(purl, default):
     elif magic_type == 'IMAGE':
         return KalturaMediaType.IMAGE
     elif default.lower() == 'video':
-        print 'failed to get type, using default.'
+        print ('failed to get type, using default.')
         return KalturaMediaType.VIDEO
     elif default.lower() == 'audio':
-        print 'failed to get type, using default.'
+        print ('failed to get type, using default.')
         return KalturaMediaType.AUDIO
     elif default.lower() == 'image':
-        print 'failed to get type, using default.'
+        print ('failed to get type, using default.')
         return KalturaMediaType.IMAGE
 
 

--- a/myKalturaObject.py
+++ b/myKalturaObject.py
@@ -1,6 +1,6 @@
 import logging
 import difflib
-from urllib import urlencode
+from urllib.parse import urlencode
 import xml.etree.ElementTree as ET
 
 from flask import current_app
@@ -273,7 +273,7 @@ def parse_caption_language(capfile, capformat):
             langcode = "en"
             logger.info('no language found in xml, defaulting to English.')
         langcode = langcode.upper()
-        print langcode
+        print (langcode)
         try:
             language = KalturaLanguage.__dict__[langcode]
         except:
@@ -293,7 +293,7 @@ def GetConfig(settings):
         raise Exception("Settings not set in GetConfig")
     partner_id = int(settings.get('PARTNER_ID'))
     service_url = settings.get('SERVICE_URL')
-    print "-> GetConfig", partner_id, service_url
+    print ("-> GetConfig", partner_id, service_url)
     config = KalturaConfiguration(partner_id)
     config.serviceUrl = service_url
     config.setLogger(KalturaLogger())
@@ -308,7 +308,7 @@ def get_new_session_key(settings):
     admin_secret = settings.get('ADMIN_SECRET')
     user_name = settings.get('USER_NAME')
     client = KalturaClient(GetConfig(settings))
-    print "-> get_new_session_key", admin_secret, user_name, partner_id
+    print ("-> get_new_session_key", admin_secret, user_name, partner_id)
     return client.session.start(admin_secret,
                                 user_name,
                                 KalturaSessionType.ADMIN,
@@ -604,7 +604,7 @@ def searchVideos(client,
     search = KalturaMediaEntryFilter()
     search.setOrderBy(KalturaMediaEntryOrderBy.CREATED_AT_ASC)
     # search.setMediaTypeEqual(KalturaMediaType.VIDEO)  # Video only
-    print "List videos, get the first one..."
+    print ("List videos, get the first one...")
     # Get 10 video entries, but we'll just use the first one returned
     entries = client.media.list(search, pager).objects
     entriesData = []

--- a/poster/streaminghttp.py
+++ b/poster/streaminghttp.py
@@ -1,6 +1,6 @@
 """Streaming HTTP uploads module.
 
-This module extends the standard httplib and urllib2 objects so that
+This module extends the standard http.client and urllib.request objects so that
 iterable objects can be used in the body of HTTP requests.
 
 In most cases all one should have to do is call :func:`register_openers()`
@@ -15,24 +15,24 @@ yielded, and there is no way to reset an interator.
 Example usage:
 
 >>> from StringIO import StringIO
->>> import urllib2, poster.streaminghttp
+>>> import urllib.request, poster.streaminghttp
 
 >>> opener = poster.streaminghttp.register_openers()
 
 >>> s = "Test file data"
 >>> f = StringIO(s)
 
->>> req = urllib2.Request("http://localhost:5000", f,
+>>> req = urllib.request.Request("http://localhost:5000", f,
 ...                       {'Content-Length': str(len(s))})
 """
 
-import httplib, urllib2, socket
-from httplib import NotConnected
+import http.client, urllib.request, socket
+from http.client import NotConnected
 
 __all__ = ['StreamingHTTPConnection', 'StreamingHTTPRedirectHandler',
         'StreamingHTTPHandler', 'register_openers']
 
-if hasattr(httplib, 'HTTPS'):
+if hasattr(http.client, 'HTTPS'):
     __all__.extend(['StreamingHTTPSHandler', 'StreamingHTTPSConnection'])
 
 class _StreamingHTTPMixin:
@@ -45,7 +45,7 @@ class _StreamingHTTPMixin:
         a .read() method, or an iterable object that supports a .next()
         method.
         """
-        # Based on python 2.6's httplib.HTTPConnection.send()
+        # Based on python 2.6's http.client.HTTPConnection.send()
         if self.sock is None:
             if self.auto_open:
                 self.connect()
@@ -58,14 +58,14 @@ class _StreamingHTTPMixin:
         # NOTE: we DO propagate the error, though, because we cannot simply
         #       ignore the error... the caller will know if they can retry.
         if self.debuglevel > 0:
-            print "send:", repr(value)
+            print ("send:", repr(value))
         try:
             blocksize = 8192
             if hasattr(value, 'read') :
                 if hasattr(value, 'seek'):
                     value.seek(0)
                 if self.debuglevel > 0:
-                    print "sendIng a read()able"
+                    print ("sendIng a read()able")
                 data = value.read(blocksize)
                 while data:
                     self.sock.sendall(data)
@@ -74,22 +74,23 @@ class _StreamingHTTPMixin:
                 if hasattr(value, 'reset'):
                     value.reset()
                 if self.debuglevel > 0:
-                    print "sendIng an iterable"
+                    print ("sendIng an iterable")
                 for data in value:
                     self.sock.sendall(data)
             else:
                 self.sock.sendall(value)
-        except socket.error, v:
+        except socket.error as v:
+        
             if v[0] == 32:      # Broken pipe
                 self.close()
             raise
 
-class StreamingHTTPConnection(_StreamingHTTPMixin, httplib.HTTPConnection):
-    """Subclass of `httplib.HTTPConnection` that overrides the `send()` method
+class StreamingHTTPConnection(_StreamingHTTPMixin, http.client.HTTPConnection):
+    """Subclass of `http.client.HTTPConnection` that overrides the `send()` method
     to support iterable body objects"""
 
-class StreamingHTTPRedirectHandler(urllib2.HTTPRedirectHandler):
-    """Subclass of `urllib2.HTTPRedirectHandler` that overrides the
+class StreamingHTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Subclass of `urllib.request.HTTPRedirectHandler` that overrides the
     `redirect_request` method to properly handle redirected POST requests
 
     This class is required because python 2.5's HTTPRedirectHandler does
@@ -97,9 +98,9 @@ class StreamingHTTPRedirectHandler(urllib2.HTTPRedirectHandler):
     the new resource, but the body of the original request is not preserved.
     """
 
-    handler_order = urllib2.HTTPRedirectHandler.handler_order - 1
+    handler_order = urllib.request.HTTPRedirectHandler.handler_order - 1
 
-    # From python2.6 urllib2's HTTPRedirectHandler
+    # From python2.6 urllib.request's HTTPRedirectHandler
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         """Return a Request or None in response to a redirect.
 
@@ -115,7 +116,7 @@ class StreamingHTTPRedirectHandler(urllib2.HTTPRedirectHandler):
             or code in (301, 302, 303) and m == "POST"):
             # Strictly (according to RFC 2616), 301 or 302 in response
             # to a POST MUST NOT cause a redirection without confirmation
-            # from the user (of urllib2, in this case).  In practice,
+            # from the user (of urllib.request, in this case).  In practice,
             # essentially all clients do redirect in this case, so we
             # do the same.
             # be conciliant with URIs containing a space
@@ -124,18 +125,18 @@ class StreamingHTTPRedirectHandler(urllib2.HTTPRedirectHandler):
                               if k.lower() not in (
                                   "content-length", "content-type")
                              )
-            return urllib2.Request(newurl,
+            return urllib.request.Request(newurl,
                            headers=newheaders,
                            origin_req_host=req.get_origin_req_host(),
                            unverifiable=True)
         else:
-            raise urllib2.HTTPError(req.get_full_url(), code, msg, headers, fp)
+            raise urllib.request.HTTPError(req.get_full_url(), code, msg, headers, fp)
 
-class StreamingHTTPHandler(urllib2.HTTPHandler):
-    """Subclass of `urllib2.HTTPHandler` that uses
+class StreamingHTTPHandler(urllib.request.HTTPHandler):
+    """Subclass of `urllib.request.HTTPHandler` that uses
     StreamingHTTPConnection as its http connection class."""
 
-    handler_order = urllib2.HTTPHandler.handler_order - 1
+    handler_order = urllib.request.HTTPHandler.handler_order - 1
 
     def http_open(self, req):
         """Open a StreamingHTTPConnection for the given request"""
@@ -152,19 +153,19 @@ class StreamingHTTPHandler(urllib2.HTTPHandler):
                 if not req.has_header('Content-length'):
                     raise ValueError(
                             "No Content-Length specified for iterable body")
-        return urllib2.HTTPHandler.do_request_(self, req)
+        return urllib.request.HTTPHandler.do_request_(self, req)
 
-if hasattr(httplib, 'HTTPS'):
+if hasattr(http.client, 'HTTPS'):
     class StreamingHTTPSConnection(_StreamingHTTPMixin,
-            httplib.HTTPSConnection):
-        """Subclass of `httplib.HTTSConnection` that overrides the `send()`
+            http.client.HTTPSConnection):
+        """Subclass of `http.client.HTTSConnection` that overrides the `send()`
         method to support iterable body objects"""
 
-    class StreamingHTTPSHandler(urllib2.HTTPSHandler):
-        """Subclass of `urllib2.HTTPSHandler` that uses
+    class StreamingHTTPSHandler(urllib.request.HTTPSHandler):
+        """Subclass of `urllib.request.HTTPSHandler` that uses
         StreamingHTTPSConnection as its http connection class."""
 
-        handler_order = urllib2.HTTPSHandler.handler_order - 1
+        handler_order = urllib.request.HTTPSHandler.handler_order - 1
 
         def https_open(self, req):
             return self.do_open(StreamingHTTPSConnection, req)
@@ -178,20 +179,20 @@ if hasattr(httplib, 'HTTPS'):
                     if not req.has_header('Content-length'):
                         raise ValueError(
                                 "No Content-Length specified for iterable body")
-            return urllib2.HTTPSHandler.do_request_(self, req)
+            return urllib.request.HTTPSHandler.do_request_(self, req)
 
 
 def register_openers():
-    """Register the streaming http handlers in the global urllib2 default
+    """Register the streaming http handlers in the global urllib.request default
     opener object.
 
     Returns the created OpenerDirector object."""
     handlers = [StreamingHTTPHandler, StreamingHTTPRedirectHandler]
-    if hasattr(httplib, "HTTPS"):
+    if hasattr(http.client, "HTTPS"):
         handlers.append(StreamingHTTPSHandler)
 
-    opener = urllib2.build_opener(*handlers)
+    opener = urllib.request.build_opener(*handlers)
 
-    urllib2.install_opener(opener)
+    urllib.request.install_opener(opener)
 
     return opener

--- a/properties.py
+++ b/properties.py
@@ -77,7 +77,7 @@ kaltura_properties_list = ['KALTURA_CONFIG_ID', 'KALTURA_NAME', 'KALTURA_PATH',
 def load_kals_from_env(SETTINGS, cur):
     kaltura_count = int(os.environ.get("KALTURA_INSTANCES", "1"))
     if kaltura_count >= 1:
-        for counter in xrange(1, kaltura_count + 1):
+        for counter in range(1, kaltura_count + 1):
             accessors = ['k_%d_%s' % (counter, kal_prop)
                          for kal_prop in kaltura_properties_list]
             # Because the Global Dictionary will be populated with this guy
@@ -257,10 +257,9 @@ def load_server_settings(SETTINGS={}):
 
 
 if __name__ == "__main__":
-    print 'KTS server settings: '
+    print ('KTS server settings: ')
     settings = load_server_settings()
     pprint(settings)
-    print ''
-    print 'Kaltura definitions: '
+    print ('Kaltura definitions: ')
     kaldefs = load_kaltura_settings()
     pprint(kaldefs)

--- a/server.py
+++ b/server.py
@@ -92,14 +92,15 @@ def _parse_ids(args, form):
 
 def kaltura_session_loader_base(kaltura_id, session):
     # Refresh Kaltura Session If not
-    print "Current in session" + repr(session)
+    print ("Current in session" + repr(session))
     kkey = 'kaltura-{}'.format(kaltura_id)
     if kkey in session and 'ksusages' in session[kkey] \
         and 'ksessionkey' in session[kkey] \
         and 'kstime' in session[kkey] and session[kkey]['ksusages'] < 5 and \
            (time.time() - session[kkey]['kstime']) < myKalturaObject.KS_EXPIRY:
-        print "I already have session. kid: {} ks: {} usages: {}".format(
-            kaltura_id, session[kkey]['ksessionkey'], session[kkey]['ksusages'])
+        print ("I already have session. kid: {} ks: {} usages: {}" . 
+        format(
+            kaltura_id, session[kkey]['ksessionkey'], session[kkey]['ksusages']))
         session[kkey]['ksusages'] += 1
         return myKalturaObject.create_session(kaltura_id,
                                               session[kkey]["ksessionkey"])
@@ -335,7 +336,7 @@ def upload_file_service():
         raise Exception("kaltura_id not provided")
         # kaltura_session = kaltura_session_loader(kaltura_id)
     if request.method == 'POST':
-        print "Inside Post Body"
+        print ("Inside Post Body")
         # Three Modes of Consumption.
         # 1. FromLocal
         # 2. File Post
@@ -343,14 +344,14 @@ def upload_file_service():
         pull_path = request.form.get('pullPath', None)
         if not pull_path:
             pull_path = request.args.get('pullPath', None)
-        print "PullPath", pull_path
+        print ("PullPath", pull_path)
 
         fromlocal = request.form.get('fromlocal', None)
         if not fromlocal:
             fromlocal = request.args.get('fromlocal', None)
-        print "FromLocal", fromlocal
+        print ("FromLocal", fromlocal)
 
-        print request.files.keys()
+        print (request.files.keys())
         medianame = request.form.get('medianame', None)
         if not medianame:
             medianame = request.args['medianame']
@@ -930,7 +931,7 @@ if not SETTINGS['DEBUG_MODE']:
         }
         return simplejson.dumps(error_dict), 500
 
-    @app.errorhandler(StandardError)
+    @app.errorhandler(Exception)
     def handle_other_errors(error):
         app.logger.exception(error.message)
         error_dict = {
@@ -944,8 +945,8 @@ if __name__ == '__main__':
     app.debug = True if SETTINGS['DEBUG_MODE'] else False
     from pprint import pprint
 
-    print "Starting with server settings"
+    print ("Starting with server settings")
     pprint(SETTINGS)
-    print "Starting with kaltura settings"
+    print ("Starting with kaltura settings")
     pprint(properties.load_kaltura_settings())
     app.run(host='0.0.0.0', port=int(SETTINGS['PORT']))

--- a/users.py
+++ b/users.py
@@ -1,3 +1,4 @@
+import six
 class User():
     i_id = None
 
@@ -16,7 +17,7 @@ class User():
         return False
 
     def get_id(self):
-        return unicode(self.i_id)
+        return isinstance(self.i_id,six.text_type)
 
     def __repr__(self):
         return '<User with id %r>' % (self.i_id)

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import logging
+import six
 import shutil
 import os
 from logging.handlers import RotatingFileHandler
@@ -31,7 +32,7 @@ def convert_file_to_unicode(filepath):
         with open(filepath, 'w') as fp:
             fp.write(utext.encode('utf8'))
     except:
-        print "Warning: Error during conversion to unicode!"
+        print ("Warning: Error during conversion to unicode!")
         os.remove(filepath)
         shutil.copy(filepath + ".bu", filepath)
     finally:
@@ -43,9 +44,9 @@ def crossdomain(origin=None, methods=None, headers=None,
                 automatic_options=True):
     if methods is not None:
         methods = ', '.join(sorted(x.upper() for x in methods))
-    if headers is not None and not isinstance(headers, basestring):
+    if headers is not None and not isinstance(headers, six.string_types):
         headers = ', '.join(x.upper() for x in headers)
-    if not isinstance(origin, basestring):
+    if not isinstance(origin, six.string_types):
         origin = ', '.join(origin)
     if isinstance(max_age, timedelta):
         max_age = max_age.total_seconds()


### PR DESCRIPTION
1. use '()' when calling print - will also work with Python2. On 3, if
   not specified, will result in syntax err.
2. use Exception as e: instead of Exception, e: - This form is also
   backwards-compatible with 2.6 and 2.7.

Changes that are not backwards compat:
1. httplib is now called http.client
2. urllib2 now called urllib.request
   4.
   isinstance(myvalue, six.string_types)       # replacement for basestring
   isinstance(myvalue, six.text_type)          # replacement for unicode
